### PR TITLE
Allow for command arguments

### DIFF
--- a/common/commands.ts
+++ b/common/commands.ts
@@ -1,36 +1,48 @@
-module Common {
+namespace Common {
     interface CommandDictionary {
         [command: string]: CommandFunction;
     }
 
     export interface CommandFunction {
-        (...rest: string[]): string;
+        (deferred: JQueryDeferred<string>, args: string[]): void;
     }
 
     export class Commands {
         private _commands: CommandDictionary = {
-            bot_time: function () {
-                return (new Date()).toString();
+            bot_time: function (deferred) {
+                deferred.resolve(new Date().toString());
             },
-            commands: () => {
-                return Object.keys(this._commands).join(', ');
+            commands: (deferred) => {
+                deferred.resolve(Object.keys(this._commands).join(', '));
             },
-            report_issue: function () {
-                return 'https://github.com/mcw8d/ChatBotExtensions/issues/new';
+            echo: function (deferred, args) {
+                deferred.resolve(`You said ${args.join('')}`);
             },
-            version: () => {
-                return this.version;
+            report_issue: function (deferred) {
+                deferred.resolve('https://github.com/mcw8d/KappaBotRelays/issues/new');
+            },
+            version: (deferred) => {
+                deferred.resolve(this.version);
             }
         }
 
         constructor (private version: string) {}
 
-        has(command: string): boolean {
-            return this._commands.hasOwnProperty(command);
+        execute(command: string, args: string[], deferred: JQueryDeferred<string>) {
+            if (this.has(command)) {
+                this.get(command)(deferred, args);
+            } else {
+                // TODO call back to localhost if a server is present.
+                deferred.reject('Command not found.');
+            }
         }
 
         get(command: string): CommandFunction {
             return this._commands[command];
+        }
+
+        has(command: string): boolean {
+            return this._commands.hasOwnProperty(command);
         }
     }
 }


### PR DESCRIPTION
Updates the command regex to check for parens surrounded text and
splits it on commas to pass to the command function. Adds an echo
command that uses the arguments passing.
Resolves #9

Also changes the message processing to a chainable promise set up
using JQuery deferreds.
