### PR TITLE
Locally unrecognized commands should be sent to a back end

### DIFF
--- a/hangouts/firefox/src/main/resources/package.json
+++ b/hangouts/firefox/src/main/resources/package.json
@@ -9,5 +9,8 @@
     "firefox": ">=38.0a1",
     "fennec": ">=38.0a1"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "permissions": {
+      "cross-domain-content": ["http://localhost:8089/"]
+  }
 }

--- a/hangouts/firefox/src/main/ts/data/bot.ts
+++ b/hangouts/firefox/src/main/ts/data/bot.ts
@@ -70,16 +70,13 @@ namespace KappaBot {
             console.debug(`Relay closing for ${this._cid}`);
         }
 
-        processMessage (message: string): JQueryDeferred<string> {
-            var deferred = $.Deferred();
+        processMessage (message: string): JQueryPromise<string> {
             var regexResults = this._commandRegEx.exec(message);
             if (regexResults !== null) {
                 var args = (regexResults[2] || '').split(',');
-                this._commands.execute(regexResults[1], args, deferred);
-            } else {
-                deferred.reject('No command present');
+                return this._commands.execute(regexResults[1], args);
             }
-            return deferred;
+            return $.Deferred<string>().reject('No command found').promise();
         }
 
         emitResponse (response: string) {

--- a/hangouts/firefox/src/main/ts/data/bot.ts
+++ b/hangouts/firefox/src/main/ts/data/bot.ts
@@ -87,7 +87,13 @@ namespace KappaBot {
             inputElement.dispatchEvent(
                 new FocusEvent('focus', {bubbles: true, cancelable: true})
             );
-            this._inputDiv.append(document.createTextNode(response));
+            var lines = response.split('\n');
+            lines.forEach((line, idx, arr) => {
+                this._inputDiv.append(document.createTextNode(line));
+                if (idx !== (arr.length - 1)) {
+                    this._inputDiv.append(document.createElement('br'));
+                }
+            });
             inputElement.dispatchEvent(
                 new KeyboardEvent('keypress', {key: 'Enter', keyCode: 13, bubbles: true, cancelable: true})
             );


### PR DESCRIPTION
If a command comes in that the local relay does not recognize then it
sends the command and it arguments to an external bot. The relay assumes
that the bot is running on localhost:8089 with a set REST API. To account for
the async nature of calling to an external program command processing has been
refactored to use JQuery deferreds.
Resolves #10
