### PR TITLE
Changing command start from #! to just !

### DIFF
--- a/hangouts/firefox/src/main/ts/data/bot.ts
+++ b/hangouts/firefox/src/main/ts/data/bot.ts
@@ -12,7 +12,7 @@ namespace KappaBot {
     export class Relay {
         private _chatContainer = $('.hN.so.Ij').children(':nth-child(2)');
         private _inputDiv = $('.vE.dQ.editable');
-        private _commandRegEx = /^#\!(\w+)(?:\((.*)\))?/;
+        private _commandRegEx = /^\!(\w+)(?:\((.*)\))?/;
         private _commands = new Common.Commands(self.options.version);
         private _currentChatObserver: MutationObserver;
         private _newChatObserver: MutationObserver;


### PR DESCRIPTION
Apparently people have trouble typing #! properly, so switching the
command regex to just look for !.
Resolves #19
